### PR TITLE
Add unstake from inactive collator

### DIFF
--- a/script/Migrate.s.sol
+++ b/script/Migrate.s.sol
@@ -7,7 +7,6 @@ import {Upgrades} from "openzeppelin-foundry-upgrades/Upgrades.sol";
 import {Core} from "openzeppelin-foundry-upgrades/internal/Core.sol";
 
 import {CollatorStakingHub} from "../src/collator/CollatorStakingHub.sol";
-import {Deposit} from "../src/deposit/Deposit.sol";
 
 contract MigrateScript is Script {
     address proxy = 0xa4fFAC7A5Da311D724eD47393848f694Baee7930;

--- a/script/Migrate.s.sol
+++ b/script/Migrate.s.sol
@@ -10,15 +10,14 @@ import {CollatorStakingHub} from "../src/collator/CollatorStakingHub.sol";
 import {Deposit} from "../src/deposit/Deposit.sol";
 
 contract MigrateScript is Script {
-    // address proxy = 0xa4fFAC7A5Da311D724eD47393848f694Baee7930;
+    address proxy = 0xa4fFAC7A5Da311D724eD47393848f694Baee7930;
 
     function run() public {
         vm.startBroadcast();
 
-        // address logic = address(new CollatorStakingHub());
-        address logic = address(new Deposit());
-        // Core.upgradeProxyTo(proxy, logic, "");
-        // require(logic == Upgrades.getImplementationAddress(proxy));
+        address logic = address(new CollatorStakingHub());
+        Core.upgradeProxyTo(proxy, logic, "");
+        require(logic == Upgrades.getImplementationAddress(proxy));
         safeconsole.log("logic: ", logic);
 
         vm.stopBroadcast();

--- a/src/collator/CollatorSet.sol
+++ b/src/collator/CollatorSet.sol
@@ -40,6 +40,10 @@ abstract contract CollatorSet is Initializable, CollatorStakingHubStorage {
         return c != address(0) && c != HEAD && c != TAIL;
     }
 
+    function _isInactiveCollator(address c) public view returns (bool) {
+        return _isValid(c) && collators[c] == address(0);
+    }
+
     function _addCollator(address cur, uint256 votes, address prev) internal {
         require(_isValid(cur), "!valid");
         address next = collators[prev];

--- a/test/collator/CollatorStakingHub.t.sol
+++ b/test/collator/CollatorStakingHub.t.sol
@@ -263,6 +263,9 @@ contract CollatorStakingHubTest is Test {
         vm.prank(alith);
         hub.stopCollation(HEAD);
 
+        assertEq(hub.votesOf(alith), 0);
+        assertEq(hub.stakedOf(alith), stake);
+
         vm.prank(alice);
         hub.unstakeDepositsFromInactiveCollator(alith, ids);
 

--- a/test/collator/CollatorStakingHub.t.sol
+++ b/test/collator/CollatorStakingHub.t.sol
@@ -149,6 +149,29 @@ contract CollatorStakingHubTest is Test {
         assertEq(IERC20(gring).balanceOf(alice), 0);
     }
 
+    function test_unstakeRINGFromInactiveCollator() public {
+        uint256 stake = 1 ether;
+        uint256 commissoin = 1;
+        vm.prank(alith);
+        address a = hub.createAndCollate(HEAD, commissoin);
+
+        vm.deal(alice, stake);
+        vm.prank(alice);
+        hub.stakeRING{value: stake}(alith, HEAD, HEAD);
+        assertEq(hub.stakingLocks(alith, alice), hub.STAKING_LOCK_PERIOD() + block.timestamp);
+
+        vm.warp(block.timestamp + hub.STAKING_LOCK_PERIOD() + 1);
+
+        vm.prank(alith);
+        hub.stopCollation(HEAD);
+
+        vm.prank(alice);
+        hub.unstakeRINGFromInactiveCollator(alith, stake);
+        assertEq(alice.balance, stake);
+        assertEq(hub.stakedOf(alith), 0);
+        assertEq(IERC20(gring).balanceOf(alice), 0);
+    }
+
     function test_stakeDeposit() public {
         uint256 stake = 1 ether;
         vm.deal(alice, stake);
@@ -203,6 +226,45 @@ contract CollatorStakingHubTest is Test {
 
         vm.prank(alice);
         hub.unstakeDeposits(alith, ids, HEAD, HEAD);
+
+        (address account, uint256 assets, address collator) = hub.depositInfos(id);
+        assertEq(account, address(0));
+        assertEq(assets, 0);
+        assertEq(collator, address(0));
+        assertEq(hub.stakedDepositsLength(alice), 0);
+        uint256[] memory deposits = hub.stakedDepositsOf(alice);
+        assertEq(deposits.length, 0);
+        assertTrue(!hub.stakedDepositsContains(alice, id));
+        assertEq(NominationPool(a).balanceOf(alice), 0);
+        assertEq(hub.votesOf(alith), 0);
+        assertEq(hub.stakedOf(alith), 0);
+        assertEq(IERC20(gring).balanceOf(alice), 0);
+    }
+
+    function test_unstakeDepositFromInactiveCollator() public {
+        uint256 stake = 1 ether;
+        vm.deal(alice, stake);
+        vm.prank(alice);
+        uint256 id = Deposit(deposit).deposit{value: stake}(1);
+
+        uint256 commissoin = 1;
+        vm.prank(alith);
+        address a = hub.createAndCollate(HEAD, commissoin);
+
+        vm.prank(alice);
+        Deposit(deposit).approve(address(hub), id);
+        vm.prank(alice);
+        uint256[] memory ids = new uint256[](1);
+        ids[0] = id;
+        hub.stakeDeposits(alith, ids, HEAD, HEAD);
+
+        vm.warp(block.timestamp + hub.STAKING_LOCK_PERIOD() + 1);
+
+        vm.prank(alith);
+        hub.stopCollation(HEAD);
+
+        vm.prank(alice);
+        hub.unstakeDepositsFromInactiveCollator(alith, ids);
 
         (address account, uint256 assets, address collator) = hub.depositInfos(id);
         assertEq(account, address(0));


### PR DESCRIPTION
- Add `unstakeRINGFromInactiveCollator ` and `unstakeDepositsFromInactiveCollator` method for nominators exit from inactive collator.
- Update migrate script.